### PR TITLE
fix(export): add generateStaticParams for /rooms/[id] and /tours/[id]

### DIFF
--- a/app/rooms/[id]/page.jsx
+++ b/app/rooms/[id]/page.jsx
@@ -59,6 +59,10 @@ const rooms = [
   },
 ];
 
+export function generateStaticParams() {
+  return rooms.map((room) => ({ id: room.id }));
+}
+
 export default function RoomDetailPage({ params }) {
   const room = rooms.find((r) => r.id === params.id);
 

--- a/app/tours/[id]/page.jsx
+++ b/app/tours/[id]/page.jsx
@@ -87,6 +87,10 @@ const tours = [
   },
 ];
 
+export function generateStaticParams() {
+  return tours.map((tour) => ({ id: tour.id }));
+}
+
 export default function TourDetailPage({ params }) {
   const tour = tours.find((t) => t.id === params.id);
 


### PR DESCRIPTION
Static export (output: 'export') requires every dynamic route to declare the params it should prerender. Map directly from the local rooms/tours arrays so the GitHub Pages build emits 6 static pages per route instead of failing with "missing generateStaticParams()".