### PR TITLE
feat(flights): expand cities, deals tabs and FAQs

### DIFF
--- a/components/flights/domesticFlightDeals.js
+++ b/components/flights/domesticFlightDeals.js
@@ -188,6 +188,22 @@ export const domesticFlightDeals = {
         tripType: "MỘT CHIỀU",
         image: "/nhom01_dulich_booking/assets/flight-destinations/con-dao.jpg",
       },
+      {
+        id: "other-6",
+        route: "TP HCM - Tuy Hòa",
+        date: DATE,
+        price: 699000,
+        tripType: "MỘT CHIỀU",
+        image: "/nhom01_dulich_booking/assets/flight-destinations/phu-yen.jpg",
+      },
+      {
+        id: "other-7",
+        route: "Hà Nội - Vinh",
+        date: DATE,
+        price: 899000,
+        tripType: "MỘT CHIỀU",
+        image: "/nhom01_dulich_booking/assets/destinations/hanoi.jpg",
+      },
     ],
   },
 };

--- a/components/flights/domesticFlightDeals.js
+++ b/components/flights/domesticFlightDeals.js
@@ -38,6 +38,9 @@ export const domesticFlightDeals = {
       { id: "hcm-4", route: "Huế - TP HCM", date: DATE, price: 899000, tripType: "MỘT CHIỀU" },
       { id: "hcm-5", route: "Quy Nhơn - TP HCM", date: DATE, price: 799000, tripType: "MỘT CHIỀU" },
       { id: "hcm-6", route: "Nha Trang - TP HCM", date: DATE, price: 599000, tripType: "MỘT CHIỀU" },
+      { id: "hcm-7", route: "Vinh - TP HCM", date: DATE, price: 999000, tripType: "MỘT CHIỀU" },
+      { id: "hcm-8", route: "Đồng Hới - TP HCM", date: DATE, price: 1099000, tripType: "MỘT CHIỀU" },
+      { id: "hcm-9", route: "Đà Lạt - TP HCM", date: DATE, price: 599000, tripType: "MỘT CHIỀU" },
     ],
   },
   "da-nang": {

--- a/components/flights/domesticFlightDeals.js
+++ b/components/flights/domesticFlightDeals.js
@@ -9,6 +9,7 @@ export const tabOrder = [
   "phu-yen",
   "hai-phong",
   "can-tho",
+  "da-lat",
   "diem-den-khac",
 ];
 
@@ -127,6 +128,17 @@ export const domesticFlightDeals = {
       { id: "ct-3", route: "Hải Phòng - Cần Thơ", date: DATE, price: 1399000, tripType: "MỘT CHIỀU" },
       { id: "ct-4", route: "Phú Quốc - Cần Thơ", date: DATE, price: 599000, tripType: "MỘT CHIỀU" },
       { id: "ct-5", route: "Quy Nhơn - Cần Thơ", date: DATE, price: 1099000, tripType: "MỘT CHIỀU" },
+    ],
+  },
+  "da-lat": {
+    label: "Đà Lạt",
+    destinationImage: "/nhom01_dulich_booking/assets/destinations/dalat.jpg",
+    cards: [
+      { id: "dl-1", route: "Hà Nội - Đà Lạt", date: DATE, price: 1199000, tripType: "MỘT CHIỀU" },
+      { id: "dl-2", route: "TP HCM - Đà Lạt", date: DATE, price: 599000, tripType: "MỘT CHIỀU" },
+      { id: "dl-3", route: "Đà Nẵng - Đà Lạt", date: DATE, price: 899000, tripType: "MỘT CHIỀU" },
+      { id: "dl-4", route: "Hải Phòng - Đà Lạt", date: DATE, price: 1399000, tripType: "MỘT CHIỀU" },
+      { id: "dl-5", route: "Vinh - Đà Lạt", date: DATE, price: 1099000, tripType: "MỘT CHIỀU" },
     ],
   },
   "diem-den-khac": {

--- a/components/flights/flightCities.js
+++ b/components/flights/flightCities.js
@@ -18,6 +18,10 @@ export const CITIES = {
   pxu: { code: "PXU", displayName: "Pleiku", aliases: ["Pleiku"] },
   bmv: { code: "BMV", displayName: "Buôn Ma Thuột", aliases: ["Buôn Ma Thuột"] },
   vcs: { code: "VCS", displayName: "Côn Đảo", aliases: ["Côn Đảo"] },
+  vii: { code: "VII", displayName: "Vinh", aliases: ["Vinh"] },
+  vdh: { code: "VDH", displayName: "Đồng Hới", aliases: ["Đồng Hới"] },
+  tbb2: { code: "TBB", displayName: "Tuy Hòa", aliases: ["Tuy Hòa"] },
+  cxr2: { code: "CXR", displayName: "Cam Ranh", aliases: ["Cam Ranh"] },
 };
 
 const aliasIndex = {};

--- a/components/flights/flightsFaqData.js
+++ b/components/flights/flightsFaqData.js
@@ -17,6 +17,12 @@ export const flightsFaqLeft = [
     answer:
       "Tùy từng hãng bay, bạn thường có thể đặt vé trước từ vài tháng đến gần một năm so với ngày khởi hành. Hãy kiểm tra lịch mở bán của hãng trên VieGo để tranh thủ giá tốt ngay khi vé được mở.",
   },
+  {
+    id: "baggage-allowance",
+    question: "Tiêu chuẩn hành lý xách tay và ký gửi như thế nào?",
+    answer:
+      "Mỗi hãng hàng không có quy định riêng về kích thước và trọng lượng hành lý. Hành lý xách tay thường được giới hạn 7-10kg, trong khi hành lý ký gửi từ 20-30kg tùy hạng vé. Bạn nên kiểm tra kỹ thông tin trên trang đặt vé hoặc website hãng bay trước chuyến đi.",
+  },
 ];
 
 export const flightsFaqRight = [
@@ -37,5 +43,11 @@ export const flightsFaqRight = [
     question: "VieGo có tính phí khi dùng thẻ tín dụng không?",
     answer:
       "Phí thanh toán bằng thẻ tín dụng phụ thuộc vào phương thức bạn chọn, ngân hàng phát hành và các chương trình khuyến mãi đang áp dụng. Bạn có thể xem chi tiết ở bước thanh toán trước khi xác nhận đặt vé.",
+  },
+  {
+    id: "child-infant",
+    question: "Trẻ em và em bé có cần mua vé riêng không?",
+    answer:
+      "Trẻ em từ 2-12 tuổi cần mua vé riêng với mức giá thường thấp hơn vé người lớn. Em bé dưới 2 tuổi thường được miễn vé hoặc tính phí rất thấp nếu ngồi cùng người lớn. Hãy chọn đúng số lượng trẻ em / em bé khi đặt vé trên VieGo để áp dụng đúng giá.",
   },
 ];


### PR DESCRIPTION
## Summary
- Thêm 4 thành phố vào city list: Vinh, Đồng Hới, Tuy Hòa, Cam Ranh
- Thêm tab "Đà Lạt" mới vào domestic flight deals (5 route)
- Thêm 3 route mới vào tab TP HCM (Vinh, Đồng Hới, Đà Lạt)
- Thêm 2 route vào tab "Điểm đến khác" (Tuy Hòa, Vinh)
- Thêm 2 FAQ mới (hành lý, vé trẻ em)

## Test plan
- [ ] `npm run dev` → mở `/flights` thấy tab Đà Lạt mới
- [ ] Tab TP HCM có thêm 3 route mới
- [ ] FAQ section có thêm 2 câu mới
