### PR TITLE
feat(account, help, contact, chatbot): expand support content and account history

### DIFF
--- a/data/accountMock.js
+++ b/data/accountMock.js
@@ -68,6 +68,33 @@ export const transactions = [
     amount: 420000,
     status: "cancelled",
   },
+  {
+    id: "VG-2026-0128-F8",
+    service: "car-rental",
+    serviceLabel: "Thuê xe",
+    title: "Toyota Vios · Đà Nẵng · 3 ngày",
+    paidAt: "2026-01-28",
+    amount: 2250000,
+    status: "success",
+  },
+  {
+    id: "VG-2025-1215-G3",
+    service: "hotel",
+    serviceLabel: "Khách sạn",
+    title: "Vinpearl Phú Quốc · 4 đêm",
+    paidAt: "2025-12-15",
+    amount: 7600000,
+    status: "success",
+  },
+  {
+    id: "VG-2025-1108-H7",
+    service: "flight",
+    serviceLabel: "Vé máy bay",
+    title: "VJ-624 TP.HCM → Phú Quốc (khứ hồi)",
+    paidAt: "2025-11-08",
+    amount: 1990000,
+    status: "success",
+  },
 ];
 
 export const refundRequests = [

--- a/data/chatbotFaq.js
+++ b/data/chatbotFaq.js
@@ -296,6 +296,45 @@ export const chatbotFaq = [
       links: [{ label: "Chính sách quyền riêng tư", href: "/privacy-policy" }],
     },
   },
+  {
+    id: "viego-points",
+    title: "Điểm thưởng VieGo Points hoạt động thế nào?",
+    keywords: [
+      "viego points",
+      "diem thuong",
+      "loyalty",
+      "tich diem",
+      "đổi điểm",
+      "điểm thưởng",
+      "tích điểm",
+    ],
+    answer: {
+      paragraphs: [
+        "Mỗi đơn hàng thành công sẽ tích điểm VieGo Points dựa trên giá trị đơn. Bạn có thể dùng điểm để giảm giá cho đơn tiếp theo hoặc đổi voucher.",
+        "Chi tiết tỷ lệ tích điểm và cách đổi quà có trong mục VieGo Points trong tài khoản.",
+      ],
+      links: [{ label: "Tìm hiểu VieGo Points", href: "/help" }],
+    },
+  },
+  {
+    id: "promo-code",
+    title: "Cách áp dụng mã giảm giá khi đặt?",
+    keywords: [
+      "ma giam gia",
+      "promo code",
+      "voucher",
+      "coupon",
+      "giảm giá",
+      "mã khuyến mãi",
+    ],
+    answer: {
+      paragraphs: [
+        "Ở bước thanh toán, bạn nhập mã vào ô 'Mã giảm giá' rồi bấm Áp dụng. Hệ thống sẽ kiểm tra điều kiện và trừ trực tiếp vào tổng đơn nếu hợp lệ.",
+        "Mỗi đơn chỉ áp dụng được 1 mã. Nếu mã không có hiệu lực, hãy kiểm tra điều kiện sử dụng và hạn dùng.",
+      ],
+      links: [{ label: "Xem ưu đãi hiện có", href: "/help" }],
+    },
+  },
 ];
 
 // Các câu hỏi gợi ý nhanh hiển thị khi mở chat.
@@ -306,6 +345,8 @@ export const quickSuggestions = [
   { id: "q-payment", label: "Phương thức thanh toán", topicId: "payment" },
   { id: "q-contact", label: "Liên hệ hỗ trợ", topicId: "contact" },
   { id: "q-bus", label: "Cách đặt vé xe khách", topicId: "bus" },
+  { id: "q-points", label: "VieGo Points là gì?", topicId: "viego-points" },
+  { id: "q-promo", label: "Áp dụng mã giảm giá", topicId: "promo-code" },
 ];
 
 export const fallbackAnswer = {

--- a/data/contactTopics.js
+++ b/data/contactTopics.js
@@ -77,4 +77,28 @@ export const contactTopicTabs = [
       },
     ],
   },
+  {
+    id: "payment",
+    label: "Thanh toán & Ví",
+    topics: [
+      {
+        id: "payment-failed",
+        question: "Thanh toán bị lỗi nhưng tài khoản đã trừ tiền?",
+        answer:
+          "Hệ thống sẽ tự động hoàn tiền về phương thức thanh toán gốc trong 3-7 ngày làm việc. Nếu sau 7 ngày chưa thấy hoàn tiền, vui lòng liên hệ hotline để được hỗ trợ.",
+      },
+      {
+        id: "viegopay-topup",
+        question: "Cách nạp tiền vào ví VieGoPay?",
+        answer:
+          "Mở 'Tài khoản' → 'VieGoPay' → 'Nạp tiền' → chọn số tiền và phương thức (chuyển khoản, thẻ, ví điện tử). Tiền sẽ vào ví ngay sau khi xác nhận thanh toán.",
+      },
+      {
+        id: "invoice-request",
+        question: "Tôi có thể yêu cầu xuất hoá đơn VAT không?",
+        answer:
+          "Có. Vào chi tiết booking → 'Yêu cầu hoá đơn' → điền thông tin công ty. VieGo sẽ phát hành hoá đơn điện tử trong 3-5 ngày làm việc và gửi qua email.",
+      },
+    ],
+  },
 ];

--- a/data/helpCategories.js
+++ b/data/helpCategories.js
@@ -10,4 +10,6 @@ export const helpCategories = [
   { id: "bus", label: "Vé xe khách", icon: "bus", color: "emerald" },
   { id: "combo", label: "Vé máy bay + Khách sạn", icon: "combo", color: "fuchsia" },
   { id: "insurance", label: "Bảo hiểm", icon: "shield", color: "indigo" },
+  { id: "car-rental", label: "Thuê xe tự lái", icon: "car", color: "orange" },
+  { id: "promotions", label: "Ưu đãi và mã giảm giá", icon: "pay", color: "pink" },
 ];

--- a/data/helpTopics.js
+++ b/data/helpTopics.js
@@ -112,4 +112,25 @@ export const helpTopics = [
       "Liên hệ đối tác bảo hiểm theo thông tin trong chứng nhận bảo hiểm, cung cấp giấy tờ liên quan (vé, hoá đơn y tế, biên bản...). Thời hạn khiếu nại thường 30 ngày sau sự cố.",
     categoryIds: ["insurance"],
   },
+  {
+    id: "car-rental-deposit",
+    question: "Tôi có cần đặt cọc khi thuê xe tự lái không?",
+    answer:
+      "Đa số đối tác yêu cầu đặt cọc bằng thẻ tín dụng hoặc tiền mặt khi nhận xe. Mức đặt cọc dao động 3-15 triệu tuỳ loại xe và sẽ được hoàn lại khi trả xe nguyên trạng.",
+    categoryIds: ["car-rental"],
+  },
+  {
+    id: "promo-stack",
+    question: "Tôi có thể dùng nhiều mã giảm giá cùng lúc không?",
+    answer:
+      "Mỗi đơn hàng chỉ áp dụng được 1 mã giảm giá. Nếu bạn có nhiều mã, hệ thống sẽ tự gợi ý mã có giá trị cao nhất phù hợp với đơn hàng hiện tại.",
+    categoryIds: ["promotions"],
+  },
+  {
+    id: "promo-expired",
+    question: "Mã giảm giá của tôi hết hạn thì làm sao?",
+    answer:
+      "Mã giảm giá đã hết hạn không thể sử dụng lại. Hãy theo dõi mục 'Ưu đãi' trong tài khoản hoặc fanpage VieGo để cập nhật mã mới được phát hành thường xuyên.",
+    categoryIds: ["promotions", "general"],
+  },
 ];


### PR DESCRIPTION
## Summary
- **Help**: thêm 2 category (Thuê xe tự lái, Ưu đãi & mã giảm giá) + 3 help topic (đặt cọc xe, mã giảm giá)
- **Contact**: thêm tab "Thanh toán & Ví" với 3 chủ đề (lỗi thanh toán, nạp VieGoPay, hoá đơn VAT)
- **Chatbot**: thêm 2 FAQ topic (VieGo Points, mã giảm giá) + 2 quick suggestion
- **Account**: thêm 3 transaction lịch sử (thuê xe Đà Nẵng, Vinpearl Phú Quốc, vé máy bay khứ hồi)

## Test plan
- [ ] `npm run dev` → mở `/help` thấy 2 category mới + 3 topic mới
- [ ] Mở `/contact` thấy tab "Thanh toán & Ví"
- [ ] Mở chatbot thấy 2 quick suggestion mới (VieGo Points, mã giảm giá)
- [ ] Mở `/account/transactions` thấy 8 giao dịch (cũ 5 + mới 3)
