### PR TITLE
fix(booking): prevent 404 when clicking "Chọn phòng" on hotel detail

### DIFF
--- a/app/booking/[locationSlug]/[hotelSlug]/page.jsx
+++ b/app/booking/[locationSlug]/[hotelSlug]/page.jsx
@@ -1,7 +1,14 @@
-export function generateStaticParams() { return [{ locationSlug: "demo", hotelSlug: "demo" }]; }
-export const dynamicParams = false;
-
+import { getAllHotelDetailParams } from "@/components/hotels/hotelResults";
 import PendingFeatureStub from "@/components/common/PendingFeatureStub";
+
+export function generateStaticParams() {
+  return getAllHotelDetailParams().map(({ slug, hotelSlug }) => ({
+    locationSlug: slug,
+    hotelSlug,
+  }));
+}
+
+export const dynamicParams = false;
 
 export default function Page() {
   return <PendingFeatureStub />;

--- a/app/booking/[locationSlug]/[hotelSlug]/payment/page.jsx
+++ b/app/booking/[locationSlug]/[hotelSlug]/payment/page.jsx
@@ -1,7 +1,14 @@
-export function generateStaticParams() { return [{ locationSlug: "demo", hotelSlug: "demo" }]; }
-export const dynamicParams = false;
-
+import { getAllHotelDetailParams } from "@/components/hotels/hotelResults";
 import PendingFeatureStub from "@/components/common/PendingFeatureStub";
+
+export function generateStaticParams() {
+  return getAllHotelDetailParams().map(({ slug, hotelSlug }) => ({
+    locationSlug: slug,
+    hotelSlug,
+  }));
+}
+
+export const dynamicParams = false;
 
 export default function Page() {
   return <PendingFeatureStub />;

--- a/app/booking/[locationSlug]/[hotelSlug]/payment/qr/page.jsx
+++ b/app/booking/[locationSlug]/[hotelSlug]/payment/qr/page.jsx
@@ -1,7 +1,14 @@
-export function generateStaticParams() { return [{ locationSlug: "demo", hotelSlug: "demo" }]; }
-export const dynamicParams = false;
-
+import { getAllHotelDetailParams } from "@/components/hotels/hotelResults";
 import PendingFeatureStub from "@/components/common/PendingFeatureStub";
+
+export function generateStaticParams() {
+  return getAllHotelDetailParams().map(({ slug, hotelSlug }) => ({
+    locationSlug: slug,
+    hotelSlug,
+  }));
+}
+
+export const dynamicParams = false;
 
 export default function Page() {
   return <PendingFeatureStub />;

--- a/app/booking/[locationSlug]/[hotelSlug]/success/page.jsx
+++ b/app/booking/[locationSlug]/[hotelSlug]/success/page.jsx
@@ -1,7 +1,14 @@
-export function generateStaticParams() { return [{ locationSlug: "demo", hotelSlug: "demo" }]; }
-export const dynamicParams = false;
-
+import { getAllHotelDetailParams } from "@/components/hotels/hotelResults";
 import PendingFeatureStub from "@/components/common/PendingFeatureStub";
+
+export function generateStaticParams() {
+  return getAllHotelDetailParams().map(({ slug, hotelSlug }) => ({
+    locationSlug: slug,
+    hotelSlug,
+  }));
+}
+
+export const dynamicParams = false;
 
 export default function Page() {
   return <PendingFeatureStub />;


### PR DESCRIPTION
## Bug
Khi user click nút "Chọn" trong section "Chọn phòng" của trang chi tiết khách sạn → trang `/booking/<location>/<hotel>` trả về **404** trên GitHub Pages.

## Root cause
4 file booking dynamic page có `generateStaticParams()` chỉ return `[{ locationSlug: "demo", hotelSlug: "demo" }]` + `dynamicParams = false` → chỉ pre-render 1 path duy nhất là `demo/demo`. Mọi URL thật (vd `vung-tau/the-grand-ho-tram-strip`) không có trong build → 404.

## Fix
Reuse helper `getAllHotelDetailParams()` (đã được trang [slug]/[hotelSlug] dùng trước đó) để generate đủ params cho mọi hotel thật. Chỉ cần map key `slug` → `locationSlug` cho khớp tên route param.

Sau fix, click "Chọn" sẽ hiện trang `PendingFeatureStub` ("Tính năng đang hoàn thiện") thay vì 404.

## Files changed
- `app/booking/[locationSlug]/[hotelSlug]/page.jsx`
- `app/booking/[locationSlug]/[hotelSlug]/payment/page.jsx`
- `app/booking/[locationSlug]/[hotelSlug]/payment/qr/page.jsx`
- `app/booking/[locationSlug]/[hotelSlug]/success/page.jsx`

## Test plan
- [ ] `npm run build` chạy không lỗi
- [ ] Sau merge, GitHub Actions deploy thành công (Actions tab)
- [ ] Click "Chọn" trên https://vutronghuy020805-sys.github.io/nhom01_dulich_booking/hotels/vung-tau/the-grand-ho-tram-strip/#rooms → KHÔNG còn 404, hiện stub "Tính năng đang hoàn thiện"
